### PR TITLE
Upgrade PHP and Laravel versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,27 +13,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3]
-        laravel: [5.8, 6.*, 7.*, 8.*, 9.*, 10.*, 11.*]
-        exclude:
-            - laravel: 9.*
-              php: 7.4
-            - laravel: 9.*
-              php: 7.3
-            - laravel: 10.*
-              php: 7.4
-            - laravel: 10.*
-              php: 7.3
-            - laravel: 10.*
-              php: 8.0
-            - laravel: 11.*
-              php: 7.4
-            - laravel: 11.*
-              php: 7.3
-            - laravel: 11.*
-              php: 8.0
-            - laravel: 11.*
-              php: 8.1
+        php: [8.3]
+        laravel: [11.*]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `laravel-fatture-in-cloud-v2` will be documented in this file
 
+## 3.0.0 - 2025-05-20
+
+- require PHP 8.3 and Laravel 11
+- update development tools
+- simplify CI matrix
+
 ## 1.0.0 - 201X-XX-XX
 
 - initial release
+

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.3",
         "ext-json": "*",
-        "illuminate/support": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "guzzlehttp/guzzle": "^5.8|^6.5|7.0.1|^7.2",
-        "illuminate/container": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "illuminate/http": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "illuminate/support": "^11.0",
+        "guzzlehttp/guzzle": "^7.2",
+        "illuminate/container": "^11.0",
+        "illuminate/http": "^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.1|^4.0|^5.0|^6.0|^7.0",
+        "orchestra/testbench": "^9.0",
         "phpstan/phpstan": "^1.7",
-        "phpunit/phpunit": "^5.8|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -7995,7 +7995,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3",
+        "php": ">=8.3",
         "ext-json": "*"
     },
     "platform-dev": [],


### PR DESCRIPTION
## Summary
- update PHP requirement to 8.3
- require Laravel 11 packages only
- bump testbench and phpunit to latest versions
- simplify CI matrix to PHP 8.3 and Laravel 11
- document major release 3.0.0 in changelog

## Testing
- `composer --version` *(fails: command not found)*