### PR TITLE
Rename supplier and product test methods

### DIFF
--- a/tests/Feature/ProductEntityTest.php
+++ b/tests/Feature/ProductEntityTest.php
@@ -244,7 +244,7 @@ class ProductEntityTest extends TestCase
         $this->assertInstanceOf(ProductEntity::class, $response);
     }
 
-    public function test_validation_error_on_create_issued_document()
+    public function test_validation_error_on_create_product()
     {
         $product = new Product();
         $response = $product->create([]);

--- a/tests/Feature/ReceiptEntityTest.php
+++ b/tests/Feature/ReceiptEntityTest.php
@@ -362,7 +362,7 @@ class ReceiptEntityTest extends TestCase
         $this->assertInstanceOf(ReceiptMonthlyTotals::class, $response[0]);
     }
 
-    public function test_validation_error_on_create_issued_document()
+    public function test_validation_error_on_monthly_totals()
     {
         $receipt = new Receipt();
         $response = $receipt->monthlyTotals('fake_type', 2022);

--- a/tests/Feature/SupplierEntityTest.php
+++ b/tests/Feature/SupplierEntityTest.php
@@ -212,7 +212,7 @@ class SupplierEntityTest extends TestCase
         $this->assertInstanceOf(SupplierEntity::class, $response);
     }
 
-    public function test_validation_error_on_create_issued_document()
+    public function test_validation_error_on_create_supplier()
     {
         $supplier = new Supplier();
         $response = $supplier->create([]);
@@ -259,7 +259,7 @@ class SupplierEntityTest extends TestCase
         $this->assertInstanceOf(SupplierEntity::class, $response);
     }
 
-    public function test_validation_error_on_edit_issued_document()
+    public function test_validation_error_on_edit_supplier()
     {
         $supplier_id = 1;
 


### PR DESCRIPTION
## Summary
- rename supplier validation error tests
- rename product validation error test
- rename receipt monthly totals validation error test

## Testing
- `composer test` *(fails: composer not installed)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*